### PR TITLE
1.2.1 - remove unused size toggle for area lamps

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -34,7 +34,7 @@ from . import axis, operators, panel
 bl_info = {
     'name': 'Light Painter',
     'author': 'Spencer Magnusson',
-    'version': (1, 2, 0),
+    'version': (1, 2, 1),
     'blender': (3, 6, 0),
     'description': 'Creates lights based on where the user paints',
     'location': 'View 3D > Light Paint',

--- a/operators/lamp_adjust_tool.py
+++ b/operators/lamp_adjust_tool.py
@@ -189,8 +189,8 @@ class LIGHTPAINTER_OT_Lamp_Adjust(bpy.types.Operator, BaseLightPaintTool, LampUt
             ) + get_drag_mode_header()
 
         return super().get_header_text() + (
-            '{}: offset mode, '
-            '{}: radius mode, '
+            '{}: offset mode, '.format(UCS['OFFSET_MODE']) +
+            ('{}: radius mode, '.format(UCS['SIZE_MODE']) if bpy.context.active_object.data.type != 'AREA' else '') +
             '{}: power mode, '
             '{}: relative power ({}), '
             '{}{}{}{}: axis ({}), '
@@ -199,8 +199,6 @@ class LIGHTPAINTER_OT_Lamp_Adjust(bpy.types.Operator, BaseLightPaintTool, LampUt
             '{}: Specular ({}), '
             '{}: Volume ({})'
         ).format(
-            UCS['OFFSET_MODE'],
-            UCS['SIZE_MODE'],
             UCS['POWER_MODE'],
             UCS['RELATIVE_POWER_TOGGLE'], 'ON' if self.is_power_relative else 'OFF',
             UCS['AXIS_X'], UCS['AXIS_Y'], UCS['AXIS_Z'], UCS['AXIS_REFLECT'], self.axis,
@@ -216,7 +214,7 @@ class LIGHTPAINTER_OT_Lamp_Adjust(bpy.types.Operator, BaseLightPaintTool, LampUt
         if is_event_command(event, 'OFFSET_MODE'):
             self.set_drag_attr('offset', mouse_x)
 
-        elif is_event_command(event, 'SIZE_MODE'):
+        elif is_event_command(event, 'SIZE_MODE') and context.active_object.data.type != 'AREA':
             self.set_drag_attr('radius', mouse_x, drag_increment=0.01, drag_precise_increment=0.001)
 
         elif is_event_command(event, 'POWER_MODE'):

--- a/operators/lamp_tool.py
+++ b/operators/lamp_tool.py
@@ -90,8 +90,11 @@ class LIGHTPAINTER_OT_Lamp(bpy.types.Operator, BaseLightPaintTool, LampUtils):
 
         return super().get_header_text() + (
             '{}: lamp type, '
-            '{}: offset mode, '
-            '{}: radius mode, '
+            '{}: offset mode, '.format(
+                UCS['TYPE_TOGGLE'],
+                UCS['OFFSET_MODE'],
+            ) +
+            ('{}: radius mode, '.format(UCS['SIZE_MODE']) if self.lamp_type != 'AREA' else '') +
             '{}: power mode, '
             '{}: relative power ({}), '
             '{}{}{}{}: axis ({}), '
@@ -100,9 +103,6 @@ class LIGHTPAINTER_OT_Lamp(bpy.types.Operator, BaseLightPaintTool, LampUtils):
             '{}: Specular ({}), '
             '{}: Volume ({})'
         ).format(
-            UCS['TYPE_TOGGLE'],
-            UCS['OFFSET_MODE'],
-            UCS['SIZE_MODE'],
             UCS['POWER_MODE'],
             UCS['RELATIVE_POWER_TOGGLE'], 'ON' if self.is_power_relative else 'OFF',
             UCS['AXIS_X'], UCS['AXIS_Y'], UCS['AXIS_Z'], UCS['AXIS_REFLECT'], self.axis,
@@ -122,7 +122,7 @@ class LIGHTPAINTER_OT_Lamp(bpy.types.Operator, BaseLightPaintTool, LampUtils):
         elif is_event_command(event, 'OFFSET_MODE'):
             self.set_drag_attr('offset', mouse_x)
 
-        elif is_event_command(event, 'SIZE_MODE'):
+        elif is_event_command(event, 'SIZE_MODE') and self.lamp_type != 'AREA':
             self.set_drag_attr('radius', mouse_x, drag_increment=0.01, drag_precise_increment=0.001)
 
         elif is_event_command(event, 'POWER_MODE'):


### PR DESCRIPTION
- #52 for Light Paint and Adjust Lamp, disable size drag mode for area lamps. It's unused since there's no "radius" parameter, and its size is dependent on the strokes themselves.