### PR TITLE
1.2.6 Optimize mesh evaluation

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -57,7 +57,7 @@ from . import axis, operators, panel
 bl_info = {
     'name': 'Light Painter',
     'author': 'Spencer Magnusson',
-    'version': (1, 2, 5),
+    'version': (1, 2, 6),
     'blender': (3, 6, 0),
     'description': 'Creates lights based on where the user paints',
     'location': 'View 3D > Light Paint',


### PR DESCRIPTION
Mitigates #50 by only evaluating if the resulting geometry has changed since the last update. Allows immediate updates for non-mesh changes (like emission value, tube radius, and opacity) without recreating the geometry.

Applies to mesh, light tube, and flag tools.