### PR TITLE
Redo panel UI rework: use_property_split

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -58,7 +58,7 @@ from . import translations
 bl_info = {
     'name': 'Light Painter',
     'author': 'Spencer Magnusson',
-    'version': (1, 3, 1),
+    'version': (1, 3, 2),
     'blender': (3, 6, 0),
     'description': 'Creates lights based on where the user paints',
     'location': 'View 3D > Light Paint',

--- a/blender_manifest.toml
+++ b/blender_manifest.toml
@@ -1,7 +1,7 @@
 schema_version = "1.0.0"
 
 id = "lightpainter"
-version = "1.3.1"
+version = "1.3.2"
 name = "Light Painter"
 tagline = "Do not place your lights, paint them"
 maintainer = "Spencer Magnusson <semagnum+blenderextensions@gmail.com>"

--- a/operators/flag_tool.py
+++ b/operators/flag_tool.py
@@ -150,17 +150,23 @@ class LIGHTPAINTER_OT_Flag(bpy.types.Operator, BaseLightPaintTool, VisibilitySet
 
     def draw(self, context):
         layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False  # No animation
 
         light_objs = get_selected_by_type(context, 'LIGHT')
         has_sun = any(obj.data.type == 'SUN' for obj in light_objs)
         has_other_lamps = any(obj.data.type != 'SUN' for obj in light_objs)
         if has_sun:
-            layout.prop(self, 'offset')
+            layout.prop(self, 'offset', text='Sun Flag Offset')
         if has_other_lamps:
-            layout.prop(self, 'factor')
+            layout.prop(self, 'factor', text='Lamp Flag Factor')
+
+        layout.separator()
 
         layout.prop(self, 'shadow_color')
         layout.prop(self, 'opacity', slider=True)
+
+        layout.separator()
 
         self.draw_visibility_props(layout)
 

--- a/operators/lamp_adjust_tool.py
+++ b/operators/lamp_adjust_tool.py
@@ -103,23 +103,25 @@ class LIGHTPAINTER_OT_Lamp_Adjust(bpy.types.Operator, BaseLightPaintTool, LampUt
 
     def draw(self, context):
         layout = self.layout
-        layout.prop(self, 'axis')
-        layout.prop(self, 'offset')
-
-        layout.separator()
+        layout.use_property_split = True
+        layout.use_property_decorate = False  # No animation
 
         lamp_type = context.active_object.data.type
 
         if lamp_type == 'SUN':
-            layout.label(text='Method:')
-            row = layout.row()
-            row.prop(self, 'normal_method', expand=True)
+            layout.prop(self, 'normal_method', expand=True)
 
             col = layout.column()
             col.active = self.normal_method == 'OCCLUSION'
             col.prop(self, 'longitude_samples')
             col.prop(self, 'latitude_samples')
             layout.prop(self, 'elevation_clamp', slider=True)
+
+            layout.separator()
+
+            col = layout.column(align=True)
+            col.prop(self, 'axis')
+            col.prop(self, 'offset', text='Amount')
 
             layout.separator()
 
@@ -138,10 +140,16 @@ class LIGHTPAINTER_OT_Lamp_Adjust(bpy.types.Operator, BaseLightPaintTool, LampUt
 
             layout.separator()
 
+            col = layout.column(align=True)
+            col.prop(self, 'axis')
+            col.prop(self, 'offset', text='Amount')
+
+            layout.separator()
+
             layout.prop(self, 'light_color')
-            row = layout.row()
-            row.prop(self, 'power')
-            row.prop(self, 'is_power_relative', toggle=True)
+            col = layout.column(align=True)
+            col.prop(self, 'power')
+            col.prop(self, 'is_power_relative')
 
         layout.separator()
 

--- a/operators/lamp_tool.py
+++ b/operators/lamp_tool.py
@@ -51,15 +51,10 @@ class LIGHTPAINTER_OT_Lamp(bpy.types.Operator, BaseLightPaintTool, LampUtils):
 
     def draw(self, _context):
         layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False  # No animation
+
         layout.prop(self, 'lamp_type')
-
-        layout.separator()
-
-        layout.prop(self, 'axis')
-        layout.prop(self, 'offset')
-
-        layout.separator()
-
         if self.lamp_type == 'AREA':
             layout.prop(self, 'shape')
             layout.prop(self, 'min_size')
@@ -71,10 +66,16 @@ class LIGHTPAINTER_OT_Lamp(bpy.types.Operator, BaseLightPaintTool, LampUtils):
 
         layout.separator()
 
+        col = layout.column(align=True)
+        col.prop(self, 'axis')
+        col.prop(self, 'offset', text='Amount')
+
+        layout.separator()
+
         layout.prop(self, 'light_color')
-        row = layout.row()
-        row.prop(self, 'power')
-        row.prop(self, 'is_power_relative', toggle=True)
+        col = layout.column(align=True)
+        col.prop(self, 'power')
+        col.prop(self, 'is_power_relative')
 
         layout.separator()
 

--- a/operators/lamp_util.py
+++ b/operators/lamp_util.py
@@ -193,7 +193,7 @@ class LampUtils(VisibilitySettings):
     )
 
     spot_blend: bpy.props.FloatProperty(
-        name='Beam Shape Blend',
+        name='Beam Blend',
         description='The softness of the spotlight edge',
         min=0.0, soft_min=0.0,
         max=1.0, soft_max=1.0,
@@ -224,7 +224,7 @@ class LampUtils(VisibilitySettings):
     )
 
     spread: bpy.props.FloatProperty(
-        name='Beam Shape Spread',
+        name='Beam Spread',
         description='How widely the emitted light fans out, as in the case of a gridded softbox (Cycles only)',
         min=0.0, soft_min=0.0,
         max=math.pi, soft_max=math.pi,

--- a/operators/mesh_tool.py
+++ b/operators/mesh_tool.py
@@ -82,15 +82,24 @@ class LIGHTPAINTER_OT_Mesh(bpy.types.Operator, BaseLightPaintTool, VisibilitySet
 
     def draw(self, _context):
         layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False  # No animation
 
-        layout.prop(self, 'axis')
-        layout.prop(self, 'offset')
-        layout.prop(self, 'flatten')
+        col = layout.column(heading='Mesh')
+        col.prop(self, 'flatten')
+
+        layout.separator()
+
+        col = layout.column(align=True)
+        col.prop(self, 'axis')
+        col.prop(self, 'offset', text='Amount')
 
         layout.separator()
 
         layout.prop(self, 'light_color')
         layout.prop(self, 'emit_value')
+
+        layout.separator()
 
         self.draw_visibility_props(layout)
 
@@ -305,25 +314,31 @@ class LIGHTPAINTER_OT_Tube_Light(bpy.types.Operator, BaseLightPaintTool, Visibil
 
     def draw(self, _context):
         layout = self.layout
-
-        layout.prop(self, 'axis')
-        layout.prop(self, 'offset')
-
-        layout.separator()
+        layout.use_property_split = True
+        layout.use_property_decorate = False  # No animation
 
         layout.prop(self, 'merge_distance')
         layout.prop(self, 'skin_radius')
         layout.prop(self, 'is_smooth')
 
-        layout.label(text='Subdivision')
-        row = layout.row()
-        row.prop(self, 'pre_subdiv', text='Path')
-        row.prop(self, 'post_subdiv', text='Surface')
+        layout.separator()
+
+        col = layout.column(align=True)
+        col.prop(self, 'pre_subdiv', text='Subdivisions Path')
+        col.prop(self, 'post_subdiv', text='Surface')
+
+        layout.separator()
+
+        col = layout.column(align=True)
+        col.prop(self, 'axis')
+        col.prop(self, 'offset', text='Amount')
 
         layout.separator()
 
         layout.prop(self, 'light_color', text='Color')
         layout.prop(self, 'emit_value')
+
+        layout.separator()
 
         self.draw_visibility_props(layout)
 

--- a/operators/sky_tool.py
+++ b/operators/sky_tool.py
@@ -92,27 +92,26 @@ class LIGHTPAINTER_OT_Sky(bpy.types.Operator, BaseLightPaintTool, VisibilitySett
 
     def draw(self, _context):
         layout = self.layout
-        layout.prop(self, 'axis')
-        layout.prop(self, 'size')
-        layout.prop(self, 'power')
+        layout.use_property_split = True
+        layout.use_property_decorate = False  # No animation
 
-        layout.separator()
-
-        layout.label(text='Sky Texture Model:')
-        row = layout.row()
-        row.prop(self, 'texture_type', expand=True)
-
-        layout.separator()
-
-        layout.label(text='Method:')
-        row = layout.row()
-        row.prop(self, 'normal_method', expand=True)
+        layout.prop(self, 'texture_type')
+        layout.prop(self, 'normal_method')
 
         col = layout.column()
         col.active = self.normal_method == 'OCCLUSION'
         col.prop(self, 'longitude_samples')
         col.prop(self, 'latitude_samples')
         col.prop(self, 'elevation_clamp', slider=True)
+
+        layout.separator()
+
+        layout.prop(self, 'axis')
+
+        layout.separator()
+
+        layout.prop(self, 'size')
+        layout.prop(self, 'power')
 
         layout.separator()
 
@@ -336,22 +335,26 @@ class LIGHTPAINTER_OT_Sun(bpy.types.Operator, BaseLightPaintTool, VisibilitySett
 
     def draw(self, _context):
         layout = self.layout
-        layout.prop(self, 'axis')
-        layout.prop(self, 'light_color')
-        layout.prop(self, 'power')
-        layout.prop(self, 'angle')
+        layout.use_property_split = True
+        layout.use_property_decorate = False  # No animation
 
-        layout.separator()
-
-        layout.label(text='Method:')
-        row = layout.row()
-        row.prop(self, 'normal_method', expand=True)
+        layout.prop(self, 'normal_method')
 
         col = layout.column()
         col.active = self.normal_method == 'OCCLUSION'
         col.prop(self, 'longitude_samples')
         col.prop(self, 'latitude_samples')
         col.prop(self, 'elevation_clamp', slider=True)
+
+        layout.separator()
+
+        layout.prop(self, 'axis')
+
+        layout.separator()
+
+        layout.prop(self, 'light_color')
+        layout.prop(self, 'power')
+        layout.prop(self, 'angle')
 
         layout.separator()
 

--- a/operators/visibility.py
+++ b/operators/visibility.py
@@ -27,8 +27,7 @@ class VisibilitySettings:
     )
 
     def draw_visibility_props(self, layout):
-        layout.label(text='Ray visibility')
-        col = layout.column_flow(align=True, columns=2)
+        col = layout.column(heading='Ray Visibility')
         col.prop(self, 'visible_camera')
         col.prop(self, 'visible_diffuse')
         col.prop(self, 'visible_specular')


### PR DESCRIPTION
#66 update redo panel UI to match other layouts in Blender, with the center alignment between property and label. A couple labels have been updated to accommodate to less text space. Some properties have been reordered, but this is to make property order consistent between tools:

- properties unique to the tool (e.g. sky texture type)
- offset/direction
- color and power
- ray visibility

I am leaving this PR up so others can review, test, and give feedback on the UI change. While not breaking, it will definitely feel different.